### PR TITLE
Minor edit to error handling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -176,7 +176,7 @@ var init = exports.init = function(host) {
             Deletes a job 
             */
             request({method: 'POST', url: build_url(DELETE, jobname)}, function(error, response, body) {
-                if ( error || response.statusCode === 404 ) {                  
+                if ( error || response.statusCode === 404 ) {
                     callback(error || true, response);
                     return;
                 }


### PR DESCRIPTION
During testing, we saw cases where `response` was undefined on error, and would subsequently break when trying to check if `statusCode` wasn't 200.

This change got us going again!
