### PR TITLE
error should never be true

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -66,7 +66,7 @@ var init = exports.init = function(host) {
             
             request({method: 'POST', url: buildurl }, function(error, response, body) {
                 if ( error || (response.statusCode !== 201 && response.statusCode !== 302) ) {
-                    callback(error || true, response);
+                    callback(error, response);
                     return;
                 }
                 data = "job is executed"


### PR DESCRIPTION
The `error` argument to `callback` should ALWAYS be an actual `Error()`.

People will try to print `err.stack` and `true.stack` is undefined.

All other callsites in this module will need fixing too.
