### PR TITLE
Jenkins returns the queue location of newly-created builds; we should too.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -74,7 +74,14 @@ var init = exports.init = function(host, options) {
                     callback(error, response);
                     return;
                 }
-                var data = "job is executed";
+                /*
+                Return queue location of newly-created job as per
+                  https://issues.jenkins-ci.org/browse/JENKINS-12827?focusedCommentId=201381#comment-201381
+                */
+                var data = {
+                    message: "job is executed",
+                    location: response.headers["Location"] || response.headers["location"]
+                };
                 callback(null, data);
             });
         },


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-12827?focusedCommentId=201381#comment-201381

This request also contains a lot of whitespace fixes.