### PR TITLE
Enable the ability to filter by view

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,7 @@ var BUILDWITHPARAMS = '%s/job/%s/buildWithParameters';
 var CONFIG = '%s/job/%s/config.xml';
 var JOBINFO = '%s/job/%s' + API;
 var LIST = '%s' + API;
+var LIST_VIEW = '%s/view/%s' + API;
 var LAST_SUCCESS = '%s/job/%s/lastSuccessfulBuild' + API;
 var TEST_REPORT = '%s/job/%s/lastSuccessfulBuild/testReport' + API;
 var LAST_BUILD = '%s/job/%s/lastBuild' + API;
@@ -111,6 +112,19 @@ var init = exports.init = function(host, options) {
                 var data = JSON.parse(body.toString()).jobs;
                 callback(null, data);
             });
+        },
+        all_jobs_in_view: function(view, callback) {
+            /*
+            Return a list of objet literals containing the name and color of all the jobs for a view on the Jenkins server
+             */
+            request({method: 'GET', url: build_url(LIST_VIEW, view)}, function (error, response, body) {
+                if ( error || response.statusCode !== 200 ) {
+                    callback(error || true, response);
+                    return;
+                }
+                var data = JSON.parse(body.toString()).jobs;
+                callback(null, data);
+            })
         },
         job_info: function(jobname, callback) {
             /*

--- a/testjenkinsapi.js
+++ b/testjenkinsapi.js
@@ -8,12 +8,24 @@ var jenkinsapi = require('./lib/main');
 
 var jenkins = jenkinsapi.init("http://localhost:8080");
 
+/*
 jenkins.build('test', function(error, data) {
     if (error) {
         console.log(error);
     }
     console.log(data);
 });
+*/
+
+/*
+var view_name = "test";
+jenkins.all_jobs_in_view(view_name, function (error, data) {
+    if (error) {
+        console.log(error);
+    }
+    console.log(data);
+});
+*/
 
 /*
 jenkins.all_jobs(function(error, data) { console.log(data)});


### PR DESCRIPTION
Allow the filtering of jobs by way of a named Jenkins view. This is useful if you have a ton of jobs on your Jenkins server.