### PR TITLE
Added proper handling of parse errors, due to malformed responses.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ var init = exports.init = function(host, options) {
         /*
         Builds REST url to Jenkins
         */
-        
+
         // Create the url using the format function
         var url = util.format.call(this, command, host);
 
@@ -55,22 +55,30 @@ var init = exports.init = function(host, options) {
         url = util.format.apply(this, args);
 
         return url;
-
-
     };
+
+    var tryParseJson = function(body, callback) {
+        try {
+            var data = JSON.parse(body.toString());
+            callback(null, data);
+        } catch (e) {
+            callback(e);
+        }
+    };
+
     return {
         build: function(jobname, params, callback) {
             var buildurl;
             /*
             Trigger Jenkins to build.
             */
-            if (typeof params === 'function') { 
+            if (typeof params === 'function') {
                 buildurl = build_url(BUILD, jobname);
                 callback = params;
             } else {
                 buildurl = build_url(BUILDWITHPARAMS+"?"+qs.stringify(params), jobname)
             }
-            
+
             request({method: 'POST', url: buildurl }, function(error, response) {
                 if ( error || (response.statusCode !== 201 && response.statusCode !== 302) ) {
                     callback(error, response);
@@ -109,8 +117,15 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString()).jobs;
-                callback(null, data);
+
+                tryParseJson(body, function(err, data) {
+                  if(err) {
+                    callback(err);
+                    return;
+                  }
+
+                  callback(null, data.jobs);
+                });
             });
         },
         all_jobs_in_view: function(view, callback) {
@@ -122,8 +137,15 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString()).jobs;
-                callback(null, data);
+
+                tryParseJson(body, function(err, data) {
+                  if(err) {
+                    callback(err);
+                    return;
+                  }
+
+                  callback(null, data.jobs);
+                });
             })
         },
         job_info: function(jobname, callback) {
@@ -135,8 +157,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         last_build_info: function(jobname, callback) {
@@ -148,8 +169,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         last_completed_build_info: function(jobname, callback) {
@@ -161,8 +181,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         build_info: function(jobname, number, callback) {
@@ -174,8 +193,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         last_build_report: function(jobname, callback) {
@@ -187,8 +205,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         get_config_xml: function(jobname, callback) {
@@ -206,16 +223,16 @@ var init = exports.init = function(host, options) {
         },
         create_job: function(jobname, job_config, callback) {
             /*
-           Create a new job based on a job_config string 
+           Create a new job based on a job_config string
             */
 
             request(
-                {method: 'POST' 
+                {method: 'POST'
                 ,url: build_url(NEWJOB, jobname)
                 ,body: job_config
                 ,headers: { "content-type": "application/xml"}
-                }, 
-                
+                },
+
                 function(error, response, body) {
                     if ( error || response.statusCode !== 200 ) {
                         callback(error || true, response);
@@ -272,7 +289,7 @@ var init = exports.init = function(host, options) {
         },
         delete_job: function(jobname, callback) {
             /*
-            Deletes a job 
+            Deletes a job
             */
             request({method: 'POST', url: build_url(DELETE, jobname)}, function(error, response, body) {
                 if ( error || response.statusCode === 404 ) {
@@ -281,7 +298,7 @@ var init = exports.init = function(host, options) {
                 }
                 callback(null, body);
             });
-            
+
         },
         disable_job: function(jobname, callback) {
             /*
@@ -316,10 +333,9 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body);
-                callback(null, data);
+                tryParseJson(body, callback);
             });
-            
+
         },
         last_result: function(jobname, callback) {
             /*
@@ -327,17 +343,16 @@ var init = exports.init = function(host, options) {
             */
             this.job_info(jobname, function(error, data) {
                 var last_result_url = data.lastBuild.url;
-                
+
                 request({method: 'GET', url: build_url(last_result_url + API, jobname)}, function(error, response, body) {
-                if ( error || response.statusCode !== 200 ) {
+                  if ( error || response.statusCode !== 200 ) {
                         callback(error || true, response);
                         return;
-                    }
-                    data = JSON.parse(body);
-                    callback(null, data);
+                  }
+                  tryParseJson(body, callback);
                 });
             });
-            
+
         },
         queue: function(callback) {
             /*
@@ -348,8 +363,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         computers: function(callback) {
@@ -361,8 +375,7 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.parse(body.toString());
-                callback(null, data);
+                tryParseJson(body, callback);
             });
         },
         job_output: function(jobname, buildname, callback) {
@@ -374,9 +387,15 @@ var init = exports.init = function(host, options) {
                     callback(error || true, response);
                     return;
                 }
-                var data = JSON.stringify({"output": body});
-                data = JSON.parse(data);
-                callback(null, data);
+
+                tryParseJson(body, function(err, data) {
+                  if(err) {
+                    callback(err);
+                    return;
+                  }
+
+                  callback(null, {"output": data});
+                });
             });
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jenkins-api",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Jenkins API written in Node.js",
   "author": "Shawn Jansepar <shawnjan@gmail.com>",
   "dependencies": {


### PR DESCRIPTION
Hi,

I'm using your lightweight api wrapper for my build monitor and had an issue with a malformed body (a proxy messed up the data). Parsing errors are catched correctly new and returned in the callback.

It would be great, if you could merge the pull request and publish a new npm package, so that I can close the issue in my project.

Regards
Marcell
