### PR TITLE
Allow falsy params in builds

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -64,7 +64,7 @@ var init = exports.init = function(host, options) {
             /*
             Trigger Jenkins to build.
             */
-            if (typeof params === 'function') { 
+            if (typeof params === 'function' || !params) { 
                 buildurl = build_url(BUILD, jobname);
                 callback = params;
             } else {


### PR DESCRIPTION
This will allow developers to use their own wrappers more easily.
build(jobname, callback) will be the same as build(jobname, null, callback).