### PR TITLE
pass request options correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,14 +397,14 @@ You can set the default configuration which will be use in all HTTP requests by 
 
 ```javascript
 // default request options
-var jenkins = jenkinsapi.init("http://jenkins.yoursite.com", {strictSSL: false});
+var jenkins = jenkinsapi.init("http://jenkins.yoursite.com", {request: {strictSSL: false}});
 ```
 
 Futhermore, you can set your remote job token for authentication:
 
 ```javascript
 // default request options
-var jenkins = jenkinsapi.init("http://jenkins.yoursite.com", {strictSSL: false}, '<job_token_here>');
+var jenkins = jenkinsapi.init("http://jenkins.yoursite.com", {request: {strictSSL: false}}, '<job_token_here>');
 ```
 
 Since node-jenkins-api uses [request/request](https://github.com/request/request) as HTTP client, please refer to the documentation for available options.


### PR DESCRIPTION
it didn't work for me before, and it seems that in the code this is how the options should be passed to the `request/request`:
https://github.com/jansepar/node-jenkins-api/blob/master/src/main.js#L262